### PR TITLE
Allow user to specify what the containing element should be when creating a new instance.

### DIFF
--- a/humane.js
+++ b/humane.js
@@ -53,6 +53,7 @@
       this.waitForMove = o.waitForMove || false
       this.clickToClose = o.clickToClose || false
       this.forceNew = o.forceNew || false
+      this.container = o.container || doc.body
 
       try { this._setupEl() } // attempt to setup elements
       catch (e) {
@@ -65,7 +66,7 @@
       _setupEl: function () {
          var el = doc.createElement('div')
          el.style.display = 'none'
-         doc.body.appendChild(el)
+         this.container.appendChild(el)
          this.el = el
          this.removeEvent = ENV.bind(this.remove,this)
          this.transEvent = ENV.bind(this._afterAnimation,this)


### PR DESCRIPTION
Right now it is always added to the body element. I wanted to add it to another element.

Usage:

```
inhumane = humane.create({container: $("#my_other_element")[0]})
inhumane.log("Displaying inside a different element!!")
```
