### PR TITLE
To prevent accessing properties of null/undefined object

### DIFF
--- a/humane.js
+++ b/humane.js
@@ -65,7 +65,10 @@
       _setupEl: function () {
          var el = doc.createElement('div')
          el.style.display = 'none'
-         if (!this.container) this.container = doc.body
+         if (!this.container){
+           if(doc.body) this.container = doc.body;
+           else throw 'document.body is null'
+         }
          this.container.appendChild(el)
          this.el = el
          this.removeEvent = ENV.bind(this.remove,this)
@@ -192,7 +195,7 @@
          ENV.off(this.el,'touchstart',this.removeEvent)
          this.removeEventsSet = false
 
-         if (cb) this.currentMsg.cb = cb
+         if (cb && this.currentMsg) this.currentMsg.cb = cb
          if (this._animating) this._hideMsg()
          else if (cb) cb()
       },


### PR DESCRIPTION
I made some change to prevent accessing properties of null/undefined object.

Every time my firebug will catch this.container is null when loading script. So I changed like this

``` javascript
         if (!this.container){
           if(doc.body) this.container = doc.body;
           else throw 'document.body is null'
         }
         this.container.appendChild(el)
```

And I'll trigger a remove() before log() to prevent stacking message. But the first time I trigger remove() . It will also triggered error. So I changed like this

``` javascript
if (cb && this.currentMsg) this.currentMsg.cb = cb
```
